### PR TITLE
Add user storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ Once completed, `fakediscord` will enable you to:
 * Test offline, without interacting with the real Discord API
 * Test with multiple simulated users, bot and non-bot
 * Trigger server-side events to test commands etc., outside the 'official' bot flow
-* Spin up a test server with a test guild already configured (simplifies local testing)
+* Spin up a test instance with guilds and users preconfigured with YAML
 
 Of course, you should also test your bot manually before releasing to the public, as there's a few things `fakediscord` **doesn't** intend to implement, including:
 
-* Authentication - any token is valid with `fakediscord`
 * Authorization - any action is allowed
 
 ## [Events](https://discord.com/developers/docs/topics/gateway-events)

--- a/internal/fakediscord/api/channel_controller.go
+++ b/internal/fakediscord/api/channel_controller.go
@@ -100,17 +100,20 @@ func createChannelMessage(c *gin.Context) {
 		return
 	}
 
+	u, ok := storage.Users.Load(c.GetString(contextKeyUserID))
+	if !ok {
+		_ = c.AbortWithError(http.StatusInternalServerError, errors.New("user missing from state"))
+		return
+	}
+
+	user := u.(discordgo.User)
+
 	m := discordgo.Message{
-		ID:        snowflake.Generate().String(),
-		ChannelID: c.Param("channel"),
-		Content:   messageSend.Content,
-		Timestamp: time.Now(),
-		// todo set author as caller identity
-		Author: &discordgo.User{
-			ID:            snowflake.Generate().String(),
-			Username:      "username",
-			Discriminator: "0000",
-		},
+		ID:          snowflake.Generate().String(),
+		ChannelID:   c.Param("channel"),
+		Content:     messageSend.Content,
+		Timestamp:   time.Now(),
+		Author:      &user,
 		Embeds:      messageSend.Embeds,
 		Attachments: buildAttachments(c.Param("channel"), messageSend.Files),
 	}

--- a/internal/fakediscord/api/configure.go
+++ b/internal/fakediscord/api/configure.go
@@ -11,6 +11,8 @@ var controllers = map[string]func(r *gin.RouterGroup){
 }
 
 func Configure(api *gin.RouterGroup) {
+	api.Use(auth)
+
 	for path, group := range controllers {
 		group(api.Group(path))
 	}

--- a/internal/fakediscord/api/middleware.go
+++ b/internal/fakediscord/api/middleware.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-const contextKeyUser = "user"
+const contextKeyUserID = "user_id"
 
 func auth(c *gin.Context) {
 	split := strings.SplitN(c.GetHeader("Authorization"), " ", 2)
@@ -25,5 +25,5 @@ func auth(c *gin.Context) {
 		return
 	}
 
-	c.Set(contextKeyUser, *u)
+	c.Set(contextKeyUserID, u.ID)
 }

--- a/internal/fakediscord/api/middleware.go
+++ b/internal/fakediscord/api/middleware.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/elliotwms/fakediscord/internal/fakediscord/storage"
+	"github.com/gin-gonic/gin"
+)
+
+const contextKeyUser = "user"
+
+func auth(c *gin.Context) {
+	split := strings.SplitN(c.GetHeader("Authorization"), " ", 2)
+	if len(split) != 2 {
+		_ = c.AbortWithError(http.StatusBadRequest, errors.New("invalid Authorization header"))
+		return
+	}
+
+	u := storage.Authenticate(split[1])
+
+	if u == nil {
+		_ = c.AbortWithError(http.StatusUnauthorized, errors.New("token not found"))
+		return
+	}
+
+	c.Set(contextKeyUser, *u)
+}

--- a/internal/fakediscord/builders/user.go
+++ b/internal/fakediscord/builders/user.go
@@ -23,6 +23,10 @@ func NewUser(username, discriminator string) *User {
 func NewUserFromConfig(config config.User) *User {
 	user := NewUser(config.Username, config.Discriminator)
 
+	if config.ID != nil {
+		user.WithID(config.ID.String())
+	}
+
 	if config.Token != "" {
 		user.WithToken(config.Token)
 	}
@@ -32,6 +36,12 @@ func NewUserFromConfig(config config.User) *User {
 
 func (u *User) Build() *discordgo.User {
 	return u.u
+}
+
+func (u *User) WithID(s string) *User {
+	u.u.ID = s
+
+	return u
 }
 
 func (u *User) WithToken(token string) *User {

--- a/internal/fakediscord/builders/user.go
+++ b/internal/fakediscord/builders/user.go
@@ -1,0 +1,41 @@
+package builders
+
+import (
+	"github.com/bwmarrin/discordgo"
+	"github.com/elliotwms/fakediscord/internal/snowflake"
+	"github.com/elliotwms/fakediscord/pkg/config"
+)
+
+type User struct {
+	u *discordgo.User
+}
+
+func NewUser(username, discriminator string) *User {
+	return &User{u: &discordgo.User{
+		ID:            snowflake.Generate().String(),
+		Username:      username,
+		Discriminator: discriminator,
+		Token:         snowflake.Generate().String(),
+		Verified:      true,
+	}}
+}
+
+func NewUserFromConfig(config config.User) *User {
+	user := NewUser(config.Username, config.Discriminator)
+
+	if config.Token != "" {
+		user.WithToken(config.Token)
+	}
+
+	return user
+}
+
+func (u *User) Build() *discordgo.User {
+	return u.u
+}
+
+func (u *User) WithToken(token string) *User {
+	u.u.Token = token
+
+	return u
+}

--- a/internal/fakediscord/fakediscord.go
+++ b/internal/fakediscord/fakediscord.go
@@ -43,8 +43,7 @@ func setupRouter() error {
 	api.WebsocketController(router.Group("ws"))
 
 	// mock the HTTP api
-	v9 := router.Group("api/v9")
-	api.Configure(v9)
+	api.Configure(router.Group("api/:version"))
 
 	return router.Run(":8080")
 }

--- a/internal/fakediscord/fakediscord.go
+++ b/internal/fakediscord/fakediscord.go
@@ -20,6 +20,12 @@ func Run(c config.Config) error {
 }
 
 func importConfig(c config.Config) {
+	for _, user := range c.Users {
+		u := builders.NewUserFromConfig(user).Build()
+
+		storage.Users.Store(u.ID, *u)
+	}
+
 	for _, guild := range c.Guilds {
 		g := builders.NewGuildFromConfig(guild).Build()
 

--- a/internal/fakediscord/storage/users.go
+++ b/internal/fakediscord/storage/users.go
@@ -1,8 +1,9 @@
 package storage
 
 import (
-	"github.com/bwmarrin/discordgo"
 	"sync"
+
+	"github.com/bwmarrin/discordgo"
 )
 
 var Users sync.Map

--- a/internal/fakediscord/storage/users.go
+++ b/internal/fakediscord/storage/users.go
@@ -1,0 +1,23 @@
+package storage
+
+import (
+	"github.com/bwmarrin/discordgo"
+	"sync"
+)
+
+var Users sync.Map
+
+func Authenticate(token string) (u *discordgo.User) {
+	Users.Range(func(key, value any) bool {
+		v := value.(*discordgo.User)
+
+		if v.Token == token {
+			u = v
+			return false
+		}
+
+		return true
+	})
+
+	return
+}

--- a/internal/fakediscord/storage/users.go
+++ b/internal/fakediscord/storage/users.go
@@ -9,10 +9,10 @@ var Users sync.Map
 
 func Authenticate(token string) (u *discordgo.User) {
 	Users.Range(func(key, value any) bool {
-		v := value.(*discordgo.User)
+		v := value.(discordgo.User)
 
 		if v.Token == token {
-			u = v
+			u = &v
 			return false
 		}
 

--- a/internal/fakediscord/storage/users_test.go
+++ b/internal/fakediscord/storage/users_test.go
@@ -1,10 +1,11 @@
 package storage
 
 import (
+	"testing"
+
 	"github.com/elliotwms/fakediscord/internal/fakediscord/builders"
 	"github.com/elliotwms/fakediscord/internal/snowflake"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/internal/fakediscord/storage/users_test.go
+++ b/internal/fakediscord/storage/users_test.go
@@ -1,0 +1,29 @@
+package storage
+
+import (
+	"github.com/elliotwms/fakediscord/internal/fakediscord/builders"
+	"github.com/elliotwms/fakediscord/internal/snowflake"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	_ = snowflake.Configure(0)
+
+	m.Run()
+}
+
+func TestUsers_Authenticate(t *testing.T) {
+	u := builders.
+		NewUser("foo", "bar").
+		WithToken("foo_token").
+		Build()
+
+	Users.Store(u.ID, u)
+
+	require.NotNil(t, Authenticate("foo_token"))
+}
+
+func TestUsers_Authenticate_TokenNotFound(t *testing.T) {
+	require.Nil(t, Authenticate("notfound"))
+}

--- a/internal/fakediscord/storage/users_test.go
+++ b/internal/fakediscord/storage/users_test.go
@@ -19,7 +19,7 @@ func TestUsers_Authenticate(t *testing.T) {
 		WithToken("foo_token").
 		Build()
 
-	Users.Store(u.ID, u)
+	Users.Store(u.ID, *u)
 
 	require.NotNil(t, Authenticate("foo_token"))
 }

--- a/internal/fakediscord/ws/ready.go
+++ b/internal/fakediscord/ws/ready.go
@@ -9,20 +9,19 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-func ready(ws *websocket.Conn) error {
+func ready(ws *websocket.Conn, u *discordgo.User) error {
 	log.Print("sending READY")
 
 	return ws.WriteJSON(Event{
 		Type:     "READY",
 		Sequence: sequence.Next(),
-		Data:     buildReady(),
+		Data:     buildReady(u),
 	})
 }
 
-func buildReady() discordgo.Ready {
+func buildReady(u *discordgo.User) discordgo.Ready {
 	r := discordgo.Ready{
-		// todo determine caller
-		User: &discordgo.User{ID: "@me"},
+		User: u,
 	}
 
 	storage.Guilds.Range(func(key, value any) bool {

--- a/internal/tests/files/config.yml
+++ b/internal/tests/files/config.yml
@@ -1,3 +1,8 @@
+users:
+  - username: HAL
+    discriminator: "9000"
+    bot: true
+    token: token
 guilds:
   - name: Test Guild
     channels:

--- a/internal/tests/message_stage_test.go
+++ b/internal/tests/message_stage_test.go
@@ -75,10 +75,12 @@ func (s *MessageStage) the_message_should_be_received() *MessageStage {
 	return s
 }
 
-func (s *MessageStage) the_message_can_be_fetched() {
+func (s *MessageStage) the_message_can_be_fetched() *MessageStage {
 	m, err := s.session.ChannelMessage(s.channel.ID, s.messageID)
 	s.require.NoError(err)
 	s.require.NotNil(m)
+
+	return s
 }
 
 func (s *MessageStage) the_message_is_pinned() {
@@ -150,4 +152,10 @@ func (s *MessageStage) the_first_attachment_should_have_a_resolution_set() {
 	attachment := s.attachments[0]
 	s.require.NotEmpty(attachment.Width)
 	s.require.NotEmpty(attachment.Height)
+}
+
+func (s *MessageStage) the_message_has_the_author_as_the_session_user() {
+	message, err := s.session.State.Message(s.channel.ID, s.messageID)
+	s.require.NoError(err)
+	s.require.Equal(s.session.State.User.ID, message.Author.ID)
 }

--- a/internal/tests/message_test.go
+++ b/internal/tests/message_test.go
@@ -13,7 +13,8 @@ func TestMessage_Send(t *testing.T) {
 
 	then.
 		the_message_should_be_received().and().
-		the_message_can_be_fetched()
+		the_message_can_be_fetched().and().
+		the_message_has_the_author_as_the_session_user()
 }
 
 func TestMessage_Pin(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,16 @@ package config
 import "github.com/bwmarrin/snowflake"
 
 type Config struct {
+	Users  []User  `yaml:"users"`
 	Guilds []Guild `yaml:"guilds"`
+}
+
+type User struct {
+	ID            *snowflake.ID `yaml:"id,omitempty"`
+	Token         string        `yaml:"token,omitempty"`
+	Username      string        `yaml:"username"`
+	Discriminator string        `yaml:"discriminator"`
+	Bot           bool          `yaml:"bot,omitempty"`
 }
 
 type Guild struct {


### PR DESCRIPTION
This PR adds persistent users for authentication, with supporting builders, storage, middleware and configuration.

It updates user-based API interactions to use the correct user (instead of previously randomly generated IDs)