### PR TITLE
feat: generate user when provided with unknown token

### DIFF
--- a/internal/fakediscord/api/middleware.go
+++ b/internal/fakediscord/api/middleware.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/elliotwms/fakediscord/internal/fakediscord/storage"
+	pkgauth "github.com/elliotwms/fakediscord/internal/fakediscord/auth"
 	"github.com/gin-gonic/gin"
 )
 
@@ -18,12 +18,5 @@ func auth(c *gin.Context) {
 		return
 	}
 
-	u := storage.Authenticate(split[1])
-
-	if u == nil {
-		_ = c.AbortWithError(http.StatusUnauthorized, errors.New("token not found"))
-		return
-	}
-
-	c.Set(contextKeyUserID, u.ID)
+	c.Set(contextKeyUserID, pkgauth.Authenticate(split[1]).ID)
 }

--- a/internal/fakediscord/auth/auth.go
+++ b/internal/fakediscord/auth/auth.go
@@ -1,0 +1,44 @@
+package auth
+
+import (
+	"fmt"
+	"github.com/bwmarrin/discordgo"
+	"github.com/elliotwms/fakediscord/internal/fakediscord/builders"
+	"github.com/elliotwms/fakediscord/internal/fakediscord/storage"
+	"log"
+	"math/rand"
+)
+
+func Authenticate(token string) *discordgo.User {
+	u := checkState(token)
+
+	if u != nil {
+		return u
+	}
+
+	u = builders.
+		NewUser(token, fmt.Sprintf("%04d", rand.Intn(10000))).
+		WithToken(token).
+		Build()
+
+	log.Printf("Created user %s with username %s for token %s\n", u.ID, u.Username, u.Token)
+
+	storage.Users.Store(u.ID, *u)
+
+	return u
+}
+
+func checkState(token string) (u *discordgo.User) {
+	storage.Users.Range(func(key, value any) bool {
+		v := value.(discordgo.User)
+
+		if v.Token == token {
+			u = &v
+			return false
+		}
+
+		return true
+	})
+
+	return
+}

--- a/internal/fakediscord/auth/auth.go
+++ b/internal/fakediscord/auth/auth.go
@@ -2,11 +2,12 @@ package auth
 
 import (
 	"fmt"
+	"log"
+	"math/rand"
+
 	"github.com/bwmarrin/discordgo"
 	"github.com/elliotwms/fakediscord/internal/fakediscord/builders"
 	"github.com/elliotwms/fakediscord/internal/fakediscord/storage"
-	"log"
-	"math/rand"
 )
 
 func Authenticate(token string) *discordgo.User {

--- a/internal/fakediscord/auth/auth_test.go
+++ b/internal/fakediscord/auth/auth_test.go
@@ -1,9 +1,10 @@
-package storage
+package auth
 
 import (
 	"testing"
 
 	"github.com/elliotwms/fakediscord/internal/fakediscord/builders"
+	"github.com/elliotwms/fakediscord/internal/fakediscord/storage"
 	"github.com/elliotwms/fakediscord/internal/snowflake"
 	"github.com/stretchr/testify/require"
 )
@@ -20,11 +21,22 @@ func TestUsers_Authenticate(t *testing.T) {
 		WithToken("foo_token").
 		Build()
 
-	Users.Store(u.ID, *u)
+	storage.Users.Store(u.ID, *u)
 
-	require.NotNil(t, Authenticate("foo_token"))
+	authedUser := Authenticate("foo_token")
+	require.NotNil(t, authedUser)
+
+	require.Equal(t, u, authedUser)
 }
 
 func TestUsers_Authenticate_TokenNotFound(t *testing.T) {
-	require.Nil(t, Authenticate("notfound"))
+	token := "notfound"
+	u := Authenticate(token)
+
+	require.NotNil(t, u)
+
+	require.NotEmpty(t, u.ID)
+	require.NotEmpty(t, u.Discriminator)
+	require.Len(t, u.Discriminator, 4)
+	require.Equal(t, token, u.Username)
 }

--- a/internal/fakediscord/storage/users.go
+++ b/internal/fakediscord/storage/users.go
@@ -1,24 +1,5 @@
 package storage
 
-import (
-	"sync"
-
-	"github.com/bwmarrin/discordgo"
-)
+import "sync"
 
 var Users sync.Map
-
-func Authenticate(token string) (u *discordgo.User) {
-	Users.Range(func(key, value any) bool {
-		v := value.(discordgo.User)
-
-		if v.Token == token {
-			u = &v
-			return false
-		}
-
-		return true
-	})
-
-	return
-}

--- a/internal/fakediscord/ws/handle.go
+++ b/internal/fakediscord/ws/handle.go
@@ -3,12 +3,12 @@ package ws
 import (
 	"encoding/json"
 	"errors"
+	"github.com/elliotwms/fakediscord/internal/fakediscord/auth"
 	"log"
 	"strings"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/elliotwms/fakediscord/internal/fakediscord/storage"
 	"github.com/gorilla/websocket"
 )
 
@@ -60,7 +60,7 @@ func establishConnection(c *websocket.Conn) error {
 
 	u, err := authUser(i.Token)
 	if err != nil {
-		//todo handle missing user with proper close (4004: "Authentication failed.")
+		log.Printf("error authing user: %s\n", err)
 		return c.Close()
 	}
 
@@ -79,7 +79,7 @@ func authUser(token string) (u *discordgo.User, err error) {
 		return nil, errors.New("malformed token")
 	}
 
-	return storage.Authenticate(s[1]), nil
+	return auth.Authenticate(s[1]), nil
 }
 
 func handleMessage(ws *websocket.Conn) error {

--- a/internal/fakediscord/ws/handle.go
+++ b/internal/fakediscord/ws/handle.go
@@ -3,12 +3,12 @@ package ws
 import (
 	"encoding/json"
 	"errors"
-	"github.com/elliotwms/fakediscord/internal/fakediscord/auth"
 	"log"
 	"strings"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/elliotwms/fakediscord/internal/fakediscord/auth"
 	"github.com/gorilla/websocket"
 )
 

--- a/internal/tests/message_stage_test.go
+++ b/internal/tests/message_stage_test.go
@@ -24,7 +24,7 @@ func NewMessageStage(t *testing.T) (given, then, when *MessageStage) {
 
 	s := &MessageStage{
 		require: r,
-		session: newSession(r),
+		session: newSession(r, "token"),
 	}
 
 	s.setup()

--- a/internal/tests/session_stage_test.go
+++ b/internal/tests/session_stage_test.go
@@ -38,7 +38,13 @@ func (s *SessionStage) and() *SessionStage {
 }
 
 func (s *SessionStage) a_new_session() *SessionStage {
-	s.session = newSession(s.require)
+	s.session = newSession(s.require, "token")
+
+	return s
+}
+
+func (s *SessionStage) a_new_session_with_token(token string) *SessionStage {
+	s.session = newSession(s.require, token)
 
 	return s
 }
@@ -104,6 +110,12 @@ func (s *SessionStage) the_session_receives_guild_create_events() *SessionStage 
 		defaultTick,
 		"did not receive expected GUILD_CREATE events. Expected: '%d', actual: '%d'", n, currLen,
 	)
+
+	return s
+}
+
+func (s *SessionStage) the_session_has_username(u string) *SessionStage {
+	s.require.Equal(u, s.ready.User.Username)
 
 	return s
 }

--- a/internal/tests/session_test.go
+++ b/internal/tests/session_test.go
@@ -20,3 +20,21 @@ func TestSession_Connects(t *testing.T) {
 		the_session_is_ready().and().
 		the_session_receives_guild_create_events()
 }
+
+func TestSession_ConnectsWithGeneratedUser(t *testing.T) {
+	given, when, then, cleanup := NewSessionStage(t)
+	defer cleanup()
+
+	given.
+		a_new_session_with_token("username").and().
+		the_session_watches_for_ready_events().and().
+		the_session_watches_for_guild_create_events()
+
+	when.
+		the_session_is_opened()
+
+	then.
+		the_session_is_ready().and().
+		the_session_has_username("username").and().
+		the_session_receives_guild_create_events()
+}

--- a/internal/tests/support_test.go
+++ b/internal/tests/support_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newSession(require *require.Assertions) *discordgo.Session {
-	session, err := discordgo.New("Bot token")
+func newSession(require *require.Assertions, token string) *discordgo.Session {
+	session, err := discordgo.New("Bot " + token)
 	require.NoError(err)
 
 	if os.Getenv("DEBUG") != "" {


### PR DESCRIPTION
chore: refactor auth into its own package so it can be used by ws and http paths
