### PR TITLE
Refactor storage pkg to use State

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /config.yml
+/sandbox

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ b --> f["fakediscord"]
 t --> f["fakediscord"]
 ```
 
-## Features
 
 `fakediscord` fakes the HTTP and WebSocket endpoints of the Discord API, triggering corresponding events via the WebSocket connection. `fakediscord` pairs well with (and is based on the hard work of) [bwmarrin/discordgo](https://github.com/bwmarrin/discordgo). 
 
@@ -91,73 +90,53 @@ sequenceDiagram
     t->>t: Assert on message
 ```
 
-## [Events](https://discord.com/developers/docs/topics/gateway-events)
+## Features
 
-As we develop `fakediscord` we will be aiming to implement each of the documented events along with their corresponding API interactions:
+`fakediscord` currently supports the following API operations, and emits the corresponding [events](https://discord.com/developers/docs/topics/gateway-events):
 
-- [ ] [Hello](https://discord.com/developers/docs/topics/gateway-events#hello)
-- [x] [Ready](https://discord.com/developers/docs/topics/gateway-events#ready)
-- [ ] [Resumed](https://discord.com/developers/docs/topics/gateway-events#resumed)
-- [ ] [Reconnect](https://discord.com/developers/docs/topics/gateway-events#reconnect)
-- [ ] [Invalid Session](https://discord.com/developers/docs/topics/gateway-events#invalid-session)
-- [ ] [Application Command Permissions Update](https://discord.com/developers/docs/topics/gateway-events#application-command-permissions-update)
-- [ ] [Auto Moderation Rule Create](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-create)
-- [ ] [Auto Moderation Rule Update](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-update)
-- [ ] [Auto Moderation Rule Delete](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-delete)
-- [ ] [Auto Moderation Action Execution](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-action-execution)
-- [x] [Channel Create](https://discord.com/developers/docs/topics/gateway-events#channel-create)
-- [ ] [Channel Update](https://discord.com/developers/docs/topics/gateway-events#channel-update)
-- [x] [Channel Delete](https://discord.com/developers/docs/topics/gateway-events#channel-delete)
-- [x] [Channel Pins Update](https://discord.com/developers/docs/topics/gateway-events#channel-pins-update)
-- [ ] [Thread Create](https://discord.com/developers/docs/topics/gateway-events#thread-create)
-- [ ] [Thread Update](https://discord.com/developers/docs/topics/gateway-events#thread-update)
-- [ ] [Thread Delete](https://discord.com/developers/docs/topics/gateway-events#thread-delete)
-- [ ] [Thread List Sync](https://discord.com/developers/docs/topics/gateway-events#thread-list-sync)
-- [ ] [Thread Member Update](https://discord.com/developers/docs/topics/gateway-events#thread-member-update)
-- [ ] [Thread Members Update](https://discord.com/developers/docs/topics/gateway-events#thread-members-update)
-- [x] [Guild Create](https://discord.com/developers/docs/topics/gateway-events#guild-create)
-- [ ] [Guild Update](https://discord.com/developers/docs/topics/gateway-events#guild-update)
-- [ ] [Guild Delete](https://discord.com/developers/docs/topics/gateway-events#guild-delete)
-- [ ] [Guild Ban Add](https://discord.com/developers/docs/topics/gateway-events#guild-ban-add)
-- [ ] [Guild Ban Remove](https://discord.com/developers/docs/topics/gateway-events#guild-ban-remove)
-- [ ] [Guild Emojis Update](https://discord.com/developers/docs/topics/gateway-events#guild-emojis-update)
-- [ ] [Guild Stickers Update](https://discord.com/developers/docs/topics/gateway-events#guild-stickers-update)
-- [ ] [Guild Integrations Update](https://discord.com/developers/docs/topics/gateway-events#guild-integrations-update)
-- [ ] [Guild Member Add](https://discord.com/developers/docs/topics/gateway-events#guild-member-add)
-- [ ] [Guild Member Remove](https://discord.com/developers/docs/topics/gateway-events#guild-member-remove)
-- [ ] [Guild Member Update](https://discord.com/developers/docs/topics/gateway-events#guild-member-update)
-- [ ] [Guild Members Chunk](https://discord.com/developers/docs/topics/gateway-events#guild-members-chunk)
-- [ ] [Guild Role Create](https://discord.com/developers/docs/topics/gateway-events#guild-role-create)
-- [ ] [Guild Role Update](https://discord.com/developers/docs/topics/gateway-events#guild-role-update)
-- [ ] [Guild Role Delete](https://discord.com/developers/docs/topics/gateway-events#guild-role-delete)
-- [ ] [Guild Scheduled Event Create](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-create)
-- [ ] [Guild Scheduled Event Update](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-update)
-- [ ] [Guild Scheduled Event Delete](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-delete)
-- [ ] [Guild Scheduled Event User Add](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-add)
-- [ ] [Guild Scheduled Event User Remove](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-remove)
-- [ ] [Integration Create](https://discord.com/developers/docs/topics/gateway-events#integration-create)
-- [ ] [Integration Update](https://discord.com/developers/docs/topics/gateway-events#integration-update)
-- [ ] [Integration Delete](https://discord.com/developers/docs/topics/gateway-events#integration-delete)
-- [x] [Interaction Create](https://discord.com/developers/docs/topics/gateway-events#interaction-create)
-- [ ] [Invite Create](https://discord.com/developers/docs/topics/gateway-events#invite-create)
-- [ ] [Invite Delete](https://discord.com/developers/docs/topics/gateway-events#invite-delete)
-- [ ] [Message Create](https://discord.com/developers/docs/topics/gateway-events#message-create)
-  - [x] Basic (via HTTP)
-  - [x] Embeds
-  - [ ] Multipart
-- [ ] [Message Update](https://discord.com/developers/docs/topics/gateway-events#message-update)
-- [x] [Message Delete](https://discord.com/developers/docs/topics/gateway-events#message-delete)
-- [ ] [Message Delete Bulk](https://discord.com/developers/docs/topics/gateway-events#message-delete-bulk)
-- [x] [Message Reaction Add](https://discord.com/developers/docs/topics/gateway-events#message-reaction-add)
-- [ ] [Message Reaction Remove](https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove)
-- [ ] [Message Reaction Remove All](https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-all)
-- [ ] [Message Reaction Remove Emoji](https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-emoji)
-- [ ] [Presence Update](https://discord.com/developers/docs/topics/gateway-events#presence-update)
-- [ ] [Stage Instance Create](https://discord.com/developers/docs/topics/gateway-events#stage-instance-create)
-- [ ] [Stage Instance Delete](https://discord.com/developers/docs/topics/gateway-events#stage-instance-delete)
-- [ ] [Stage Instance Update](https://discord.com/developers/docs/topics/gateway-events#stage-instance-update)
-- [ ] [Typing Start](https://discord.com/developers/docs/topics/gateway-events#typing-start)
-- [ ] [User Update](https://discord.com/developers/docs/topics/gateway-events#user-update)
-- [ ] [Voice State Update](https://discord.com/developers/docs/topics/gateway-events#voice-state-update)
-- [ ] [Voice Server Update](https://discord.com/developers/docs/topics/gateway-events#voice-server-update)
-- [ ] [Webhooks Update](https://discord.com/developers/docs/topics/gateway-events#webhooks-update)
+#### Gateway
+
+* Get Gateway
+* Connect
+  * `HELLO`
+  * `READY`
+  * [`GUILD_CREATE`](https://discord.com/developers/docs/events/gateway-events#guild-create)
+
+### Guilds
+
+* [Create](https://discord.com/developers/docs/resources/guild#create-guild)
+  * [`GUILD_CREATE`](https://discord.com/developers/docs/events/gateway-events#guild-create)
+* [Get](https://discord.com/developers/docs/resources/guild#get-guild)
+* [Delete](https://discord.com/developers/docs/resources/guild#delete-guild)
+  * [`GUILD_DELETE`](https://discord.com/developers/docs/events/gateway-events#guild-delete)
+* [Get channels](https://discord.com/developers/docs/resources/guild#get-guild-channels)
+* [Create channel](https://discord.com/developers/docs/resources/guild#create-guild-channel)
+  * [`CHANNEL_CREATE`](https://discord.com/developers/docs/events/gateway-events#channel-create)
+
+### Channels
+
+* [Get](https://discord.com/developers/docs/resources/channel#get-channel)
+* [Delete](https://discord.com/developers/docs/resources/channel#deleteclose-channel)
+  * [`CHANNEL_DELETE`](https://discord.com/developers/docs/events/gateway-events#channel-delete)
+* [Get Pinned Messages](https://discord.com/developers/docs/resources/channel#get-pinned-messages)
+* [Pin Message](https://discord.com/developers/docs/resources/channel#pin-message)
+  * [`CHANNEL_PINS_UPDATE`](https://discord.com/developers/docs/events/gateway-events#channel-pins-update)
+
+### Messages
+
+* [Create Message](https://discord.com/developers/docs/resources/message#create-message)
+  * [`MESSAGE_CREATE`](https://discord.com/developers/docs/events/gateway-events#message-create)
+  * Supports basic, embeds and multipart 
+* [Get Message](https://discord.com/developers/docs/resources/message#get-channel-message)
+* [Delete Message](https://discord.com/developers/docs/resources/message#delete-message)
+  * [`MESSAGE_DELETE`](https://discord.com/developers/docs/resources/message#delete-message)
+* [Get Message Reactions](https://discord.com/developers/docs/resources/message#get-reactions)
+* [Create Reaction](https://discord.com/developers/docs/resources/message#create-reaction)
+  * [`MESSAGE_REACTION_ADD`](https://discord.com/developers/docs/events/gateway-events#message-reaction-add)
+* [Delete Reactions](https://discord.com/developers/docs/resources/message#delete-all-reactions)
+  * [`MESSAGE_REACTION_REMOVE_ALL`](https://discord.com/developers/docs/events/gateway-events#message-reaction-remove-all)
+
+### Interactions
+
+* Create (see [docs](#interactions))
+* [Callback](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback)

--- a/internal/fakediscord/api/applications_controller.go
+++ b/internal/fakediscord/api/applications_controller.go
@@ -25,13 +25,10 @@ func applicationsController(r *gin.RouterGroup) {
 func postGuildCommand(c *gin.Context) {
 	guildID := c.Param("guild")
 
-	v, ok := storage.Users.Load(c.GetString(contextKeyUserID))
-	if !ok {
-		_ = c.AbortWithError(http.StatusInternalServerError, errors.New("user not found"))
+	u, done := getUser(c)
+	if done {
 		return
 	}
-
-	u := v.(discordgo.User)
 
 	command := &discordgo.ApplicationCommand{
 		ID:            snowflake.Generate().String(),

--- a/internal/fakediscord/api/channel_controller.go
+++ b/internal/fakediscord/api/channel_controller.go
@@ -33,6 +33,7 @@ func channelController(r *gin.RouterGroup) {
 	r.POST("/:channel/messages", createChannelMessage)
 	r.GET("/:channel/messages/:message", getChannelMessage)
 	r.DELETE("/:channel/messages/:message", deleteChannelMessage)
+
 	r.GET("/:channel/messages/:message/reactions/:reaction", getMessageReaction)
 	r.PUT("/:channel/messages/:message/reactions/:reaction/:user", putMessageReaction)
 	r.DELETE("/:channel/messages/:message/reactions", deleteMessageReactions)
@@ -276,6 +277,7 @@ func deleteChannelMessage(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
+// https://discord.com/developers/docs/resources/message#get-reactions
 func getMessageReaction(c *gin.Context) {
 	vs, _ := storage.Reactions.LoadMessageReaction(c.Param("message"), c.Param("reaction"))
 
@@ -287,6 +289,7 @@ func getMessageReaction(c *gin.Context) {
 	c.JSON(http.StatusOK, users)
 }
 
+// https://discord.com/developers/docs/resources/message#create-reaction
 func putMessageReaction(c *gin.Context) {
 	v, ok := storage.Channels.Load(c.Param("channel"))
 	if !ok {
@@ -339,6 +342,7 @@ func putMessageReaction(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
+// https://discord.com/developers/docs/resources/message#delete-all-reactions
 func deleteMessageReactions(c *gin.Context) {
 	v, ok := storage.Messages.Load(c.Param("message"))
 	if !ok {

--- a/internal/fakediscord/api/helpers.go
+++ b/internal/fakediscord/api/helpers.go
@@ -1,12 +1,26 @@
 package api
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/elliotwms/fakediscord/internal/fakediscord/storage"
 	"github.com/elliotwms/fakediscord/internal/fakediscord/ws"
+	"github.com/gin-gonic/gin"
 )
+
+func getUser(c *gin.Context) (discordgo.User, bool) {
+	u, ok := storage.Users.Load(c.GetString(contextKeyUserID))
+	if !ok {
+		_ = c.AbortWithError(http.StatusInternalServerError, errors.New("user missing from state"))
+		return discordgo.User{}, true
+	}
+
+	user := u.(discordgo.User)
+	return user, false
+}
 
 // sendMessage stores the message in fakediscord's internal state and dispatches a create/update event (depending on
 // if the message is new).

--- a/internal/fakediscord/api/helpers.go
+++ b/internal/fakediscord/api/helpers.go
@@ -27,10 +27,17 @@ func getUser(c *gin.Context) (discordgo.User, bool) {
 func sendMessage(m *discordgo.Message) (*discordgo.MessageCreate, error) {
 	t := "MESSAGE_CREATE"
 
-	_, loaded := storage.Messages.Swap(m.ID, *m)
-	if loaded {
+	// check if message already exists
+	_, err := storage.State.Message(m.ChannelID, m.ID)
+	if err == nil {
 		// message already exists, update it instead
 		t = "MESSAGE_UPDATE"
+	}
+
+	// update state with latest message
+	err = storage.State.MessageAdd(m)
+	if err != nil {
+		return nil, err
 	}
 
 	messageCreate := &discordgo.MessageCreate{Message: m}

--- a/internal/fakediscord/api/helpers.go
+++ b/internal/fakediscord/api/helpers.go
@@ -39,3 +39,12 @@ func sendMessage(m *discordgo.Message) (*discordgo.MessageCreate, error) {
 	}
 	return messageCreate, nil
 }
+
+func handleStateErr(c *gin.Context, err error) {
+	if errors.Is(err, discordgo.ErrStateNotFound) {
+		c.AbortWithStatus(http.StatusNotFound)
+		return
+	}
+
+	_ = c.AbortWithError(http.StatusInternalServerError, err)
+}

--- a/internal/fakediscord/api/interactions_controller.go
+++ b/internal/fakediscord/api/interactions_controller.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -32,9 +31,8 @@ func createInteraction(c *gin.Context) {
 		return
 	}
 
-	u, ok := storage.Users.Load(c.GetString(contextKeyUserID))
-	if !ok {
-		_ = c.AbortWithError(http.StatusInternalServerError, errors.New("user not found"))
+	u, done := getUser(c)
+	if done {
 		return
 	}
 
@@ -48,7 +46,7 @@ func createInteraction(c *gin.Context) {
 	// generate ID and token
 	interaction.ID = id
 	interaction.Token = token
-	interaction.AppID = u.(discordgo.User).ID
+	interaction.AppID = u.ID
 
 	storage.Interactions.Store(interaction.Token, *interaction.Interaction)
 

--- a/internal/fakediscord/api/interactions_controller.go
+++ b/internal/fakediscord/api/interactions_controller.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -23,32 +24,25 @@ func interactionsController(r *gin.RouterGroup) {
 }
 
 func createInteraction(c *gin.Context) {
-	// create interaction ID
-	interaction := &discordgo.InteractionCreate{}
-
-	if err := c.BindJSON(interaction); err != nil {
-		_ = c.AbortWithError(http.StatusBadRequest, err)
-		return
-	}
-
 	u, done := getUser(c)
 	if done {
 		return
 	}
 
-	id := snowflake.Generate().String()
+	interaction := &discordgo.Interaction{}
+	if err := c.BindJSON(interaction); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 
-	// token appears to be just random bytes
-	token := base64.StdEncoding.EncodeToString([]byte(
-		fmt.Sprintf("interaction:%s:%s", id, snowflake.Generate().String()),
-	))
+	setInteractionDefaults(interaction, u)
 
-	// generate ID and token
-	interaction.ID = id
-	interaction.Token = token
-	interaction.AppID = u.ID
+	if err := validateInteraction(interaction); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 
-	storage.Interactions.Store(interaction.Token, *interaction.Interaction)
+	storage.Interactions.Store(interaction.Token, *interaction)
 
 	// todo send to webhook (query param?)
 
@@ -60,6 +54,95 @@ func createInteraction(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, interaction)
+}
+
+// setInteractionDefaults sets some default values when creating a new interaction
+func setInteractionDefaults(interaction *discordgo.Interaction, u discordgo.User) {
+	if interaction.ID == "" {
+		interaction.ID = snowflake.Generate().String()
+	}
+
+	if interaction.Token == "" {
+		// token appears to be just random bytes
+		interaction.Token = base64.StdEncoding.EncodeToString([]byte(
+			fmt.Sprintf("interaction:%s:%s", interaction.ID, snowflake.Generate().String()),
+		))
+	}
+
+	if interaction.AppID == "" {
+		interaction.AppID = u.ID
+	}
+}
+
+func validateInteraction(interaction *discordgo.Interaction) error {
+	var errs []error
+
+	if interaction.ID == "" {
+		errs = append(errs, errors.New("missing id"))
+	}
+
+	if interaction.AppID == "" {
+		errs = append(errs, errors.New("missing app_id"))
+	}
+
+	if interaction.Type == 0 {
+		errs = append(errs, errors.New("missing type"))
+	} else {
+		switch interaction.Type {
+		case discordgo.InteractionApplicationCommand, discordgo.InteractionApplicationCommandAutocomplete:
+			errs = validateApplicationCommandData(interaction, errs)
+		case discordgo.InteractionMessageComponent:
+			errs = validateMessageComponentData(interaction, errs)
+		case discordgo.InteractionModalSubmit:
+			errs = validateModalSubmitData(interaction, errs)
+		}
+	}
+
+	if interaction.GuildID == "" {
+		errs = append(errs, errors.New("missing guild_id"))
+	}
+
+	if interaction.ChannelID == "" {
+		errs = append(errs, errors.New("missing channel_id"))
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateModalSubmitData(interaction *discordgo.Interaction, errs []error) []error {
+	data := interaction.ModalSubmitData()
+	if data.CustomID == "" {
+		errs = append(errs, errors.New("missing data.custom_id"))
+	}
+	return errs
+}
+
+func validateMessageComponentData(interaction *discordgo.Interaction, errs []error) []error {
+	data := interaction.MessageComponentData()
+	if data.CustomID == "" {
+		errs = append(errs, errors.New("missing data.custom_id"))
+	}
+
+	if data.ComponentType == 0 {
+		errs = append(errs, errors.New("missing data.component_type"))
+	}
+	return errs
+}
+
+func validateApplicationCommandData(interaction *discordgo.Interaction, errs []error) []error {
+	data := interaction.ApplicationCommandData()
+	if data.ID == "" {
+		errs = append(errs, errors.New("missing data.id"))
+	}
+
+	if data.Name == "" {
+		errs = append(errs, errors.New("missing data.name"))
+	}
+
+	if data.CommandType == 0 {
+		errs = append(errs, errors.New("missing data.command_type"))
+	}
+	return errs
 }
 
 func postCallback(c *gin.Context) {

--- a/internal/fakediscord/api/webhooks_controller.go
+++ b/internal/fakediscord/api/webhooks_controller.go
@@ -124,6 +124,4 @@ func updateMessage(m *discordgo.Message, edit *discordgo.WebhookEdit) {
 	}
 
 	// todo allowed mentions?
-
-	return
 }

--- a/internal/fakediscord/api/webhooks_controller.go
+++ b/internal/fakediscord/api/webhooks_controller.go
@@ -30,14 +30,20 @@ func webhooksController(r *gin.RouterGroup) {
 func getResponse(c *gin.Context) {
 	mID, ok := storage.InteractionResponses.Load(c.Param("token"))
 	if !ok {
-		_ = c.AbortWithError(http.StatusNotFound, errors.New("token not found"))
+		_ = c.AbortWithError(http.StatusNotFound, errors.New("interaction not found"))
 		return
 	}
 
-	slog.Info("loading message", "id", mID)
-	m, ok := storage.Messages.Load(mID)
+	v, ok := storage.Interactions.Load(c.Param("token"))
 	if !ok {
-		_ = c.AbortWithError(http.StatusNotFound, errors.New("message not found"))
+		_ = c.AbortWithError(http.StatusNotFound, errors.New("interaction not found"))
+	}
+	i := v.(discordgo.Interaction)
+
+	slog.Info("loading message", "id", mID)
+	m, err := storage.State.Message(i.ChannelID, mID.(string))
+	if err != nil {
+		handleStateErr(c, err)
 		return
 	}
 
@@ -60,7 +66,8 @@ func patchResponse(c *gin.Context) {
 	}
 	interaction := v.(discordgo.Interaction)
 
-	id, _ := storage.InteractionResponses.LoadOrStore(token, snowflake.Generate().String())
+	v, _ = storage.InteractionResponses.LoadOrStore(token, snowflake.Generate().String())
+	id := v.(string)
 
 	v, ok = storage.Users.Load(interaction.AppID)
 	if !ok {
@@ -69,21 +76,25 @@ func patchResponse(c *gin.Context) {
 	}
 	user := v.(discordgo.User)
 
-	v, ok = storage.Messages.LoadOrStore(
-		id,
-		*builders.NewMessage(&user, interaction.ChannelID, interaction.GuildID).
-			WithID(id.(string)).
-			WithType(discordgo.MessageTypeReply).
-			Build(),
-	)
-	if !ok {
+	m, err := storage.State.Message(interaction.ChannelID, id)
+	if err != nil {
+		if !errors.Is(err, discordgo.ErrStateNotFound) {
+			_ = c.AbortWithError(http.StatusInternalServerError, err)
+			return
+		}
+
+		// build a new message
 		slog.Info("message not found, creating new message", "id", id, "token", token)
+
+		m = builders.NewMessage(&user, interaction.ChannelID, interaction.GuildID).
+			WithID(id).
+			WithType(discordgo.MessageTypeReply).
+			Build()
 	}
-	m := v.(discordgo.Message)
 
-	m = updateMessage(m, edit)
+	updateMessage(m, edit)
 
-	mc, err := sendMessage(&m)
+	mc, err := sendMessage(m)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusInternalServerError, err)
 		return
@@ -92,7 +103,8 @@ func patchResponse(c *gin.Context) {
 	c.JSON(http.StatusOK, mc)
 }
 
-func updateMessage(m discordgo.Message, edit *discordgo.WebhookEdit) discordgo.Message {
+// updateMessage applies the discordgo.WebhookEdit to the message
+func updateMessage(m *discordgo.Message, edit *discordgo.WebhookEdit) {
 	if edit.Content != nil {
 		m.Content = *edit.Content
 	}
@@ -113,5 +125,5 @@ func updateMessage(m discordgo.Message, edit *discordgo.WebhookEdit) discordgo.M
 
 	// todo allowed mentions?
 
-	return m
+	return
 }

--- a/internal/fakediscord/builders/guild.go
+++ b/internal/fakediscord/builders/guild.go
@@ -1,6 +1,8 @@
 package builders
 
 import (
+	"time"
+
 	"github.com/bwmarrin/discordgo"
 	"github.com/elliotwms/fakediscord/internal/snowflake"
 	"github.com/elliotwms/fakediscord/pkg/config"
@@ -47,4 +49,29 @@ func (g *Guild) WithChannel(channel *discordgo.Channel) *Guild {
 	g.g.Channels = append(g.g.Channels, channel)
 
 	return g
+}
+
+func (g *Guild) WithUsers(users []*discordgo.User) *Guild {
+	for _, user := range users {
+		g.g.Members = append(g.g.Members, NewMember(g.g.ID, user).Build())
+	}
+	return g
+}
+
+type Member struct {
+	m *discordgo.Member
+}
+
+func NewMember(guildID string, u *discordgo.User) *Member {
+	return &Member{
+		m: &discordgo.Member{
+			GuildID:  guildID,
+			JoinedAt: time.Now(),
+			User:     u,
+		},
+	}
+}
+
+func (m *Member) Build() *discordgo.Member {
+	return m.m
 }

--- a/internal/fakediscord/fakediscord.go
+++ b/internal/fakediscord/fakediscord.go
@@ -57,11 +57,6 @@ func generate(c config.Config) {
 		if err != nil {
 			panic(err)
 		}
-
-		for _, channel := range g.Channels {
-			slog.Info("Creating test channel", "name", channel.Name, "id", channel.ID)
-			storage.Channels.Store(channel.ID, *channel)
-		}
 	}
 }
 

--- a/internal/fakediscord/storage/storage.go
+++ b/internal/fakediscord/storage/storage.go
@@ -1,19 +1,24 @@
 package storage
 
 import (
+	"math"
 	"sync"
 
 	"github.com/bwmarrin/discordgo"
 )
 
-var State = discordgo.NewState()
+func init() {
+	State = discordgo.NewState()
+	State.MaxMessageCount = math.MaxInt
+}
 
 var (
+	State *discordgo.State
+
 	Commands             sync.Map // Command ID : discordgo.ApplicationCommand
 	CommandNames         sync.Map // type:name : Command ID
 	Interactions         sync.Map // token : discordgo.Interaction
 	InteractionResponses sync.Map // token : Message ID
 	InteractionCallbacks sync.Map // Interaction ID : {}
-	Messages             sync.Map // id : discordgo.Message
 	Users                sync.Map // User ID : discordgo.User
 )

--- a/internal/fakediscord/storage/storage.go
+++ b/internal/fakediscord/storage/storage.go
@@ -9,7 +9,6 @@ import (
 var State = discordgo.NewState()
 
 var (
-	Channels             sync.Map // Channel ID : discordgo.Channel
 	Commands             sync.Map // Command ID : discordgo.ApplicationCommand
 	CommandNames         sync.Map // type:name : Command ID
 	Interactions         sync.Map // token : discordgo.Interaction

--- a/internal/fakediscord/storage/storage.go
+++ b/internal/fakediscord/storage/storage.go
@@ -1,12 +1,17 @@
 package storage
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+var State = discordgo.NewState()
 
 var (
 	Channels             sync.Map // Channel ID : discordgo.Channel
 	Commands             sync.Map // Command ID : discordgo.ApplicationCommand
 	CommandNames         sync.Map // type:name : Command ID
-	Guilds               sync.Map // Guild ID : discordgo.Guild
 	Interactions         sync.Map // token : discordgo.Interaction
 	InteractionResponses sync.Map // token : Message ID
 	InteractionCallbacks sync.Map // Interaction ID : {}

--- a/internal/fakediscord/ws/ready.go
+++ b/internal/fakediscord/ws/ready.go
@@ -24,15 +24,16 @@ func buildReady(u *discordgo.User) discordgo.Ready {
 		User: u,
 	}
 
-	storage.Guilds.Range(func(key, value any) bool {
+	storage.State.RLock()
+	defer storage.State.RUnlock()
+
+	for _, guild := range storage.State.Guilds {
 		r.Guilds = append(r.Guilds, &discordgo.Guild{
 			// READY returns a stripped down guild containing just the ID and availability
-			ID:          key.(string),
+			ID:          guild.ID,
 			Unavailable: true,
 		})
-
-		return true
-	})
+	}
 
 	return r
 }

--- a/internal/tests/guild_stage_test.go
+++ b/internal/tests/guild_stage_test.go
@@ -1,0 +1,101 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/require"
+)
+
+type GuildStage struct {
+	t       *testing.T
+	require *require.Assertions
+	session *discordgo.Session
+
+	guildName string
+
+	err         error
+	guild       *discordgo.Guild
+	guildCreate *discordgo.GuildCreate
+	guildDelete *discordgo.GuildDelete
+}
+
+func NewGuildStage(t *testing.T) (*GuildStage, *GuildStage, *GuildStage) {
+	session, closer := newOpenSession(t, botToken)
+	t.Cleanup(closer)
+
+	s := &GuildStage{
+		t:       t,
+		require: require.New(t),
+		session: session,
+	}
+
+	return s, s, s
+}
+
+func (s *GuildStage) and() *GuildStage {
+	return s
+}
+
+func (s *GuildStage) a_guild_named(name string) *GuildStage {
+	s.guildName = name
+
+	return s
+}
+
+func (s *GuildStage) the_session_expects_a_guild_create_event_for_the_guild() {
+	s.session.AddHandler(func(_ *discordgo.Session, e *discordgo.GuildCreate) {
+		s.t.Logf("Received %s event for guild '%s'", "GUILD_CREATE", e.Guild.Name)
+		if e.Guild.Name == s.guildName {
+			s.guildCreate = e
+		}
+	})
+}
+
+func (s *GuildStage) the_guild_is_created() *GuildStage {
+	s.guild, s.err = s.session.GuildCreate(s.guildName)
+
+	return s
+}
+
+func (s *GuildStage) no_error_should_be_returned() *GuildStage {
+	s.require.NoError(s.err)
+
+	return s
+}
+
+func (s *GuildStage) the_session_should_have_received_the_guild_create_event() {
+	s.require.Eventually(func() bool {
+		return s.guildCreate != nil
+	}, time.Second, time.Millisecond*10)
+}
+
+func (s *GuildStage) the_session_expects_a_guild_delete_event_for_the_guild() *GuildStage {
+	s.session.AddHandler(func(_ *discordgo.Session, e *discordgo.GuildDelete) {
+		s.t.Logf("Received %s event for guild '%s'", "GUILD_DELETE", e.Guild.ID)
+		if e.Guild.ID == s.guild.ID {
+			s.guildDelete = e
+		}
+	})
+
+	return s
+}
+
+func (s *GuildStage) the_guild_is_deleted() {
+	s.err = s.session.GuildDelete(s.guild.ID)
+}
+
+func (s *GuildStage) the_session_should_have_received_the_guild_deleted_event() {
+	s.require.Eventually(func() bool {
+		return s.guildDelete != nil
+	}, time.Second, time.Millisecond*10)
+}
+
+func (s *GuildStage) the_guild_is_fetched() {
+	s.guild, s.err = s.session.Guild(s.guild.ID)
+}
+
+func (s *GuildStage) an_error_should_be_returned() {
+	s.require.Error(s.err)
+}

--- a/internal/tests/guild_test.go
+++ b/internal/tests/guild_test.go
@@ -1,0 +1,59 @@
+package tests
+
+import "testing"
+
+func TestGuild_Create(t *testing.T) {
+	given, when, then := NewGuildStage(t)
+
+	given.
+		a_guild_named("create_test").and().
+		the_session_expects_a_guild_create_event_for_the_guild()
+
+	when.
+		the_guild_is_created()
+
+	then.
+		no_error_should_be_returned().and().
+		the_session_should_have_received_the_guild_create_event()
+}
+
+func TestGuild_Get(t *testing.T) {
+	given, when, then := NewGuildStage(t)
+
+	given.
+		a_guild_named("create_test").and().
+		the_guild_is_created()
+
+	when.
+		the_guild_is_fetched()
+
+	then.
+		no_error_should_be_returned()
+}
+
+func TestGuild_Delete(t *testing.T) {
+	given, when, then := NewGuildStage(t)
+
+	t.Run("delete", func(t *testing.T) {
+		given.
+			a_guild_named("delete_test").and().
+			the_session_expects_a_guild_delete_event_for_the_guild().and().
+			the_guild_is_created().and()
+
+		when.
+			the_guild_is_deleted()
+
+		then.
+			no_error_should_be_returned().and().
+			the_session_should_have_received_the_guild_deleted_event()
+	})
+
+	t.Run("get_deleted", func(t *testing.T) {
+		// test guild not found
+		when.
+			the_guild_is_fetched()
+
+		then.
+			an_error_should_be_returned()
+	})
+}

--- a/internal/tests/interactions_test.go
+++ b/internal/tests/interactions_test.go
@@ -2,25 +2,94 @@ package tests
 
 import "testing"
 
-func TestInteraction(t *testing.T) {
+func TestInteraction_Create(t *testing.T) {
 	given, when, then := NewInteractionStage(t)
 
 	given.
-		a_registered_message_command_handler()
+		a_registered_message_command_handler().and().
+		a_valid_interaction()
 
 	when.
-		an_interaction_is_triggered()
+		the_interaction_is_triggered()
 
 	then.
+		no_error_should_be_returned().and().
 		the_interaction_should_be_valid().and().
 		the_command_handler_should_have_been_triggered()
+}
+
+func TestInteraction_Create_Invalid(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		given, when, then := NewInteractionStage(t)
+
+		given.
+			an_interaction()
+
+		when.
+			the_interaction_is_triggered()
+
+		then.
+			an_error_should_be_returned()
+
+	})
+
+	t.Run("missing type", func(t *testing.T) {
+		given, when, then := NewInteractionStage(t)
+
+		given.
+			an_interaction().and().
+			the_interaction_has_guild_id().and().
+			the_interaction_has_channel_id()
+
+		when.
+			the_interaction_is_triggered()
+
+		then.
+			an_error_should_be_returned().and().
+			the_error_should_contain("missing type")
+	})
+
+	t.Run("missing guild id", func(t *testing.T) {
+		given, when, then := NewInteractionStage(t)
+
+		given.
+			an_interaction().and().
+			the_interaction_has_type().and().
+			the_interaction_has_data().and().
+			the_interaction_has_channel_id()
+
+		when.
+			the_interaction_is_triggered()
+
+		then.
+			an_error_should_be_returned().and().
+			the_error_should_contain("missing guild_id")
+
+	})
+
+	t.Run("missing channel id", func(t *testing.T) {
+		given, when, then := NewInteractionStage(t)
+
+		given.
+			an_interaction().and().
+			the_interaction_has_type().and().
+			the_interaction_has_data().and().
+			the_interaction_has_guild_id()
+
+		when.
+			the_interaction_is_triggered()
+
+		then.
+			an_error_should_be_returned().and().
+			the_error_should_contain("missing channel_id")
+	})
 }
 
 func TestInteraction_Callback(t *testing.T) {
 	given, when, then := NewInteractionStage(t)
 
 	given.
-		an_interaction_is_triggered()
+		the_interaction_is_triggered()
 
 	when.
 		the_interaction_callback_is_triggered().and().
@@ -34,7 +103,7 @@ func TestInteraction_Callback_WithMessage(t *testing.T) {
 	given, when, then := NewInteractionStage(t)
 
 	given.
-		an_interaction_is_triggered()
+		the_interaction_is_triggered()
 
 	when.
 		the_interaction_callback_is_triggered_with_a_message()

--- a/internal/tests/setup_test.go
+++ b/internal/tests/setup_test.go
@@ -65,6 +65,22 @@ func newSession(token string) *discordgo.Session {
 	return session
 }
 
+func newOpenSession(t *testing.T, token string) (session *discordgo.Session, closer func()) {
+	session = newSession(token)
+
+	err := session.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return session, func() {
+		err = session.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func setupGuild(s *discordgo.Session, name string) (*discordgo.Guild, *discordgo.Channel, error) {
 	guild, err := s.GuildCreate(fmt.Sprintf("%s_test", name))
 	if err != nil {

--- a/pkg/fakediscord/client.go
+++ b/pkg/fakediscord/client.go
@@ -3,6 +3,7 @@ package fakediscord
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -53,6 +54,18 @@ func (c *Client) Interaction(i *discordgo.InteractionCreate) (*discordgo.Interac
 	}
 
 	if res.StatusCode != http.StatusCreated {
+		if res.StatusCode == http.StatusBadRequest {
+			s := &struct {
+				Error string `json:"error"`
+			}{}
+
+			err = json.NewDecoder(res.Body).Decode(s)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse interaction response: %w", err)
+			}
+
+			return nil, errors.New(s.Error)
+		}
 		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
 	}
 


### PR DESCRIPTION
This PR refactors several components of the storage package to use the builtin `discordgo.State`, which provides convenient helpers for working with guilds, channels and messages in memory.

It also adds interaction validation, to ensure that mimimum required fields are being set on the `POST /interactions` endpoint

It also updates the readme (closes #11 ) 