### PR TITLE
fix: Add missing return after error in postGuildChannels

### DIFF
--- a/internal/fakediscord/api/guilds_controller.go
+++ b/internal/fakediscord/api/guilds_controller.go
@@ -99,7 +99,8 @@ func postGuildChannels(c *gin.Context) {
 
 	err := c.BindJSON(&channel)
 	if err != nil {
-		_ = c.AbortWithError(http.StatusInternalServerError, err)
+		_ = c.AbortWithError(http.StatusBadRequest, err)
+		return
 	}
 
 	channel.ID = snowflake.Generate().String()


### PR DESCRIPTION
The error handling in postGuildChannels was missing a return statement, causing the function to continue executing after BindJSON failed. Also changed the error status from 500 to 400 since this is a client error.

https://claude.ai/code/session_01CjoDEU4CwACHNVNJ7xEVCG